### PR TITLE
Implement whoami

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ path = "src/bin/su.rs"
 name = "sudo"
 path = "src/bin/sudo.rs"
 
+[[bin]]
+name = "whoami"
+path = "src/bin/whoami.rs"
+
 [dependencies]
 argon2rs = { version = "0.2", default-features = false }
 liner = "0.1"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ This repository contains utilities for user and group management for Redox. Addi
 - `id`
 - `login`
 - `sudo`
+- `whoami`

--- a/src/bin/whoami.rs
+++ b/src/bin/whoami.rs
@@ -1,0 +1,5 @@
+use std::env;
+
+pub fn main() {
+    println!("{}", env::var("USER").unwrap_or(String::new()));
+}


### PR DESCRIPTION
This pull request implements the `whoami` command. Works the same way as the already existing `id` command by getting the name of the current user from the environment variables.