### PR TITLE
Move hard paths to vars.

### DIFF
--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -16,7 +16,7 @@ use userutils::Passwd;
 pub fn main() {
     let mut stdout = io::stdout();
 
-    if let Ok(mut issue) = File::open("/etc/issue") {
+    if let Ok(mut issue) = File::open(userutils::FILE_ISSUE) {
         io::copy(&mut issue, &mut stdout).unwrap();
         let _ = stdout.flush();
     }
@@ -28,7 +28,7 @@ pub fn main() {
             let mut stdin = stdin.lock();
 
             let mut passwd_string = String::new();
-            File::open("/etc/passwd").unwrap().read_to_string(&mut passwd_string).unwrap();
+            File::open(userutils::FILE_PASSWD).unwrap().read_to_string(&mut passwd_string).unwrap();
 
             let mut passwd_option = None;
             for line in passwd_string.lines() {
@@ -62,7 +62,7 @@ pub fn main() {
             }
 
             if let Some(passwd) = passwd_option  {
-                if let Ok(mut motd) = File::open("/etc/motd") {
+                if let Ok(mut motd) = File::open(userutils::FILE_MOTD) {
                     io::copy(&mut motd, &mut stdout).unwrap();
                     let _ = stdout.flush();
                 }

--- a/src/bin/passwd.rs
+++ b/src/bin/passwd.rs
@@ -19,7 +19,7 @@ fn main() {
     let uid = syscall::getuid().unwrap() as u32;
 
     let mut passwd_string = String::new();
-    File::open("/etc/passwd").unwrap().read_to_string(&mut passwd_string).unwrap();
+    File::open(userutils::FILE_PASSWD).unwrap().read_to_string(&mut passwd_string).unwrap();
 
     let passwd = if let Some(user) = env::args().nth(1) {
         let mut passwd_option = None;

--- a/src/bin/su.rs
+++ b/src/bin/su.rs
@@ -26,7 +26,7 @@ pub fn main() {
     let uid = syscall::getuid().unwrap();
 
     let mut passwd_string = String::new();
-    File::open("/etc/passwd").unwrap().read_to_string(&mut passwd_string).unwrap();
+    File::open(userutils::FILE_PASSWD).unwrap().read_to_string(&mut passwd_string).unwrap();
 
     let mut passwd_option = None;
     for line in passwd_string.lines() {

--- a/src/bin/sudo.rs
+++ b/src/bin/sudo.rs
@@ -21,7 +21,7 @@ pub fn main() {
 
             if uid != 0 {
                 let mut passwd_string = String::new();
-                if let Ok(mut file) = File::open("/etc/passwd") {
+                if let Ok(mut file) = File::open(userutils::FILE_PASSWD) {
                     let _ = file.read_to_string(&mut passwd_string);
                 }
 
@@ -42,7 +42,7 @@ pub fn main() {
                     },
                     Some(passwd) => {
                         let mut group_string = String::new();
-                        if let Ok(mut file) = File::open("/etc/group") {
+                        if let Ok(mut file) = File::open(userutils::FILE_GROUP) {
                             let _ = file.read_to_string(&mut group_string);
                         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,11 @@ extern crate argon2rs;
 use argon2rs::verifier::Encoded;
 use argon2rs::{Argon2, Variant};
 
+pub static FILE_ISSUE:   &'static str = "/etc/issue";
+pub static FILE_PASSWD:  &'static str = "/etc/passwd";
+pub static FILE_GROUP:   &'static str = "/etc/group";
+pub static FILE_MOTD:    &'static str = "/etc/motd";
+
 pub struct Passwd<'a> {
     pub user: &'a str,
     pub hash: &'a str,


### PR DESCRIPTION
This issue was raised in the redox-os/redox repo, but referenced redox-os/userutils - move hard-coded paths to variables.