### PR TITLE
Add additional flags to user and groupadd; Update Cargo files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "redox_users"
 version = "0.1.0"
-source = "git+https://github.com/redox-os/users.git?branch=goyox86/failure#47a167cdf2aa64a857190274de7d1a03d43405b6"
+source = "git+https://github.com/redox-os/users.git#90e5ffe4df14361e9032c35bd96c38be8558a822"
 dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "extra 0.1.0 (git+https://github.com/redox-os/libextra.git)",
@@ -255,7 +255,7 @@ dependencies = [
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.1.0 (git+https://github.com/redox-os/users.git?branch=goyox86/failure)",
+ "redox_users 0.1.0 (git+https://github.com/redox-os/users.git)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -294,7 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum redox_users 0.1.0 (git+https://github.com/redox-os/users.git?branch=goyox86/failure)" = "<none>"
+"checksum redox_users 0.1.0 (git+https://github.com/redox-os/users.git)" = "<none>"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum scoped_threadpool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4ea459fe3ceff01e09534847c49860891d3ff1c12b4eb7731b67f2778fb60190"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,5 @@ liner = "0.1"
 rand = "0.3"
 redox_syscall = "0.1"
 redox_termios = "0.1"
-# TODO: Change this to the master branch
-redox_users = { git = "https://github.com/redox-os/users.git", branch = "goyox86/failure" }
+redox_users = { git = "https://github.com/redox-os/users.git" }
 termion = "1.5.1"

--- a/src/bin/groupadd.rs
+++ b/src/bin/groupadd.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 use std::process::exit;
 
 use arg_parser::ArgParser;
-use redox_users::{add_group, get_unique_group_id};
+use redox_users::{add_group, get_group_by_id, get_unique_group_id, UsersError};
 
 const MAN_PAGE: &'static str = /* @MANSTART{groupadd} */ r#"
 NAME
@@ -31,6 +31,11 @@ OPTIONS
         even if the group already exists. A message is still
         printed to stdout.
 
+    -g, --gid GID
+        The group id to use. This value must not be used and must
+        be non-negative. The default is to pick the smallest available
+        group id (between values defined in redox_users).
+
     -h, --help
         Display this help and exit.
 
@@ -45,7 +50,8 @@ fn main() {
     
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"])
-        .add_flag(&["f", "force"]);
+        .add_flag(&["f", "force"])
+        .add_opt("g", "gid");
     parser.parse(env::args());
     
     // Shows the help
@@ -62,19 +68,42 @@ fn main() {
         &parser.args[0]
     };
     
-    let gid = match get_unique_group_id() {
-        Some(gid) => gid,
-        None => {
-            eprintln!("groupadd: no available gid");
+    let gid = if let Some(gid) = parser.get_opt("gid") {
+        let gid = gid.parse::<u32>().unwrap_or_else(|err| {
+            eprintln!("groupadd: {}", err);
             exit(1);
+        });
+        match get_group_by_id(gid as usize) {
+            Ok(_) => {
+                eprintln!("groupadd: group already exists");
+                exit(1);
+            },
+            Err(ref err) if err.downcast_ref::<UsersError>() == Some(&UsersError::AlreadyExists) => {
+                gid
+            },
+            Err(err) => {
+                eprintln!("groupadd: {}", err);
+                exit(1);
+            }
+        }
+    } else {
+        match get_unique_group_id() {
+            Some(gid) => gid,
+            None => {
+                eprintln!("groupadd: no available gid");
+                exit(1);
+            }
         }
     };
     
     match add_group(groupname, gid, &[""]) {
         Ok(_) => { },
+        Err(ref err) if err.downcast_ref::<UsersError>() == Some(&UsersError::AlreadyExists) && parser.found("force") => {
+            exit(0);
+        },
         Err(err) => {
             eprintln!("groupadd: {}", err);
-            exit(1)
+            exit(1);
         }
     }
 }


### PR DESCRIPTION
Basically now we don't require pulling from @goyox86 's branch of redox_users anymore :P

I added three new flags to useradd and groupadd collectively and rearranged some things in there to make those flags work. I also made sure that `--force` for groupadd works.