### PR TITLE
Using new 'unwrap_or_exit' from libextra.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 [[package]]
 name = "extra"
 version = "0.1.0"
-source = "git+https://github.com/redox-os/libextra.git#402932084acd5fef4812945887ceaaa2ddd5f264"
+source = "git+https://github.com/redox-os/libextra.git#f38608acd9cc00e1c8bd41a1a96d31becf239913"
 
 [[package]]
 name = "failure"

--- a/src/bin/groupadd.rs
+++ b/src/bin/groupadd.rs
@@ -47,32 +47,30 @@ fn main() {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
     let mut stderr = io::stderr();
-    
+
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"])
         .add_flag(&["f", "force"])
         .add_opt("g", "gid");
     parser.parse(env::args());
-    
+
     // Shows the help
     if parser.found("help") {
         stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
         stdout.flush().try(&mut stderr);
         exit(0);
     }
-    
+
     let groupname = if parser.args.is_empty() {
         eprintln!("groupadd: no group name specified");
         exit(1);
     } else {
         &parser.args[0]
     };
-    
+
     let gid = if let Some(gid) = parser.get_opt("gid") {
-        let gid = gid.parse::<u32>().unwrap_or_else(|err| {
-            eprintln!("groupadd: {}", err);
-            exit(1);
-        });
+        let gid = gid.parse::<u32>().unwrap_or_exit(1);
+
         match get_group_by_id(gid as usize) {
             Ok(_) => {
                 eprintln!("groupadd: group already exists");
@@ -95,7 +93,7 @@ fn main() {
             }
         }
     };
-    
+
     match add_group(groupname, gid, &[""]) {
         Ok(_) => { },
         Err(ref err) if err.downcast_ref::<UsersError>() == Some(&UsersError::AlreadyExists) && parser.found("force") => {

--- a/src/bin/id.rs
+++ b/src/bin/id.rs
@@ -97,15 +97,9 @@ pub fn main() {
             exit(1);
         }
 
-        let egid = get_egid().unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let egid = get_egid().unwrap_or_exit(1);
 
-        let gid = get_gid().unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let gid = get_gid().unwrap_or_exit(1);
 
         print_msg(&format!("{} {}\n", egid, gid), &mut stdout, &mut stderr);
         exit(0);
@@ -128,15 +122,9 @@ pub fn main() {
             get_euid()
         };
 
-        let uid = uid_result.unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let uid = uid_result.unwrap_or_exit(1);
 
-        let user = get_user_by_id(uid).unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let user = get_user_by_id(uid).unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", user.user), &mut stdout, &mut stderr);
         exit(0);
@@ -144,10 +132,7 @@ pub fn main() {
 
     // Display real user ID
     if parser.found(&'u') && parser.found(&'r') {
-        let uid = get_uid().unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let uid = get_uid().unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", uid), &mut stdout, &mut stderr);
         exit(0);
@@ -155,10 +140,7 @@ pub fn main() {
 
     // Display effective user ID
     if parser.found(&'u') {
-        let euid = get_euid().unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let euid = get_euid().unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", euid), &mut stdout, &mut stderr);
         exit(0);
@@ -173,15 +155,9 @@ pub fn main() {
             get_egid()
         };
 
-        let gid = gid_result.unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let gid = gid_result.unwrap_or_exit(1);
 
-        let group = get_group_by_id(gid).unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let group = get_group_by_id(gid).unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", group.group), &mut stdout, &mut stderr);
         exit(0);
@@ -189,10 +165,7 @@ pub fn main() {
 
     // Display the real group ID
     if parser.found(&'g') && parser.found(&'r') {
-        let gid = get_gid().unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let gid = get_gid().unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", gid), &mut stdout, &mut stderr);
         exit(0);
@@ -200,10 +173,7 @@ pub fn main() {
 
     // Display effective group ID
     if parser.found(&'g') {
-        let egid = get_egid().unwrap_or_else(|err| {
-            eprintln!("id: {}", err);
-            exit(1);
-        });
+        let egid = get_egid().unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", egid), &mut stdout, &mut stderr);
         exit(0);
@@ -222,25 +192,13 @@ pub fn main() {
     }
 
     // We get everything we can and show
-    let euid = get_euid().unwrap_or_else(|err| {
-        eprintln!("id: {}", err);
-        exit(1);
-    });
+    let euid = get_euid().unwrap_or_exit(1);
 
-    let egid = get_egid().unwrap_or_else(|err| {
-        eprintln!("id: {}", err);
-        exit(1);
-    });
+    let egid = get_egid().unwrap_or_exit(1);
 
-    let user = get_user_by_id(euid).unwrap_or_else(|err| {
-        eprintln!("id: {}", err);
-        exit(1);
-    });
+    let user = get_user_by_id(euid).unwrap_or_exit(1);
 
-    let group = get_group_by_id(egid).unwrap_or_else(|err| {
-        eprintln!("id: {}", err);
-        exit(1);
-    });
+    let group = get_group_by_id(egid).unwrap_or_exit(1);
 
     let msg = format!("uid={}({}) gid={}({})\n", euid, user.user, egid, group.group);
     print_msg(&msg, &mut stdout, &mut stderr);

--- a/src/bin/passwd.rs
+++ b/src/bin/passwd.rs
@@ -57,22 +57,13 @@ fn main() {
         exit(0);
     }
 
-    let uid = get_uid().unwrap_or_else(|err| {
-        eprintln!("passwd: {}", err);
-        exit(1);
-    });
+    let uid = get_uid().unwrap_or_exit(1);
     
     let user = if parser.args.is_empty() {
-        get_user_by_id(uid).unwrap_or_else(|err| {
-            eprintln!("passwd: {}", err);
-            exit(1);
-        })
+        get_user_by_id(uid).unwrap_or_exit(1)
     } else {
         let username = &parser.args[0];
-        get_user_by_name(username).unwrap_or_else(|err| {
-            eprintln!("passwd: {}", err);
-            exit(1);
-        })
+        get_user_by_name(username).unwrap_or_exit(1)
     };
 
     let uid = uid as u32;

--- a/src/bin/su.rs
+++ b/src/bin/su.rs
@@ -63,15 +63,9 @@ pub fn main() {
         parser.args[0].to_string()
     };
 
-    let uid = get_uid().unwrap_or_else(|err|{
-        eprintln!("su: {}", err);
-        exit(1);
-    });
+    let uid = get_uid().unwrap_or_exit(1);
 
-    let user = get_user_by_name(&target_user).unwrap_or_else(|err| {
-        eprintln!("su: {}", err);
-        exit(1);
-    });
+    let user = get_user_by_name(&target_user).unwrap_or_exit(1);
 
     if uid > 0 || user.hash != "" {
         stdout.write_all(b"password: ").try(&mut stderr);

--- a/src/bin/sudo.rs
+++ b/src/bin/sudo.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 
 extern crate arg_parser;
+extern crate extra;
 extern crate syscall;
 extern crate termion;
 extern crate redox_users;
@@ -11,6 +12,7 @@ use std::os::unix::process::CommandExt;
 use std::process::{Command, exit};
 
 use arg_parser::ArgParser;
+use extra::option::OptionalExt;
 use termion::input::TermRead;
 use redox_users::{get_uid, get_user_by_id, get_group_by_name};
 
@@ -65,21 +67,12 @@ pub fn main() {
         exit(1);
     });
 
-    let uid = get_uid().unwrap_or_else(|err| {
-        eprintln!("sudo: {}", err);
-        exit(1);
-    });
+    let uid = get_uid().unwrap_or_exit(1);
 
-    let user = get_user_by_id(uid).unwrap_or_else(|err| {
-        eprintln!("sudo: {}", err);
-        exit(1);
-    });
+    let user = get_user_by_id(uid).unwrap_or_exit(1);
 
     if uid != 0 {
-        let sudo_group = get_group_by_name("sudo").unwrap_or_else(|err| {
-            eprintln!("sudo: {}", err);
-            exit(1);
-        });
+        let sudo_group = get_group_by_name("sudo").unwrap_or_exit(1);
 
         if sudo_group.users.iter().any(|name| name == &user.user) {
             if ! user.hash.is_empty() {

--- a/src/bin/useradd.rs
+++ b/src/bin/useradd.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 
 extern crate arg_parser;
+extern crate extra;
 extern crate redox_users;
 
 use std::{env, io};
@@ -10,6 +11,7 @@ use std::os::unix::fs::DirBuilderExt;
 use std::process::exit;
 
 use arg_parser::ArgParser;
+use extra::option::OptionalExt;
 use redox_users::{add_group, add_user, get_unique_group_id, get_unique_user_id};
 
 const MAN_PAGE: &'static str = /* @MANSTART{useradd} */ r#"
@@ -100,10 +102,7 @@ fn main() {
     
     let uid = if parser.found("uid") {
         match parser.get_opt("uid") {
-            Some(uid) => uid.parse::<u32>().unwrap_or_else(|err| {
-                eprintln!("useradd: invalid uid value: {}", err);
-                exit(1);
-            }),
+            Some(uid) => uid.parse::<u32>().unwrap_or_exit(1),
             None => {
                 eprintln!("useradd: missing uid value");
                 exit(1);
@@ -127,10 +126,7 @@ fn main() {
     } else {
         if parser.found("gid") {
             gid = match parser.get_opt("gid") {
-                Some(gid) => gid.parse::<u32>().unwrap_or_else(|err| {
-                    eprintln!("useradd: invalid argument to gid: {}", err);
-                    exit(1);
-                }),
+                Some(gid) => gid.parse::<u32>().unwrap_or_exit(1),
                 None => {
                     eprintln!("useradd: missing gid argument");
                     exit(1);

--- a/src/bin/whoami.rs
+++ b/src/bin/whoami.rs
@@ -48,15 +48,9 @@ fn main() {
         exit(0);
     }
 
-    let euid = get_euid().unwrap_or_else(|err| {
-        println!("whoami: {}", err);
-        exit(1);
-    });
+    let euid = get_euid().unwrap_or_exit(1);
 
-    let user = get_user_by_id(euid).unwrap_or_else(|err| {
-        println!("whoami: {}", err);
-        exit(1);
-    });
+    let user = get_user_by_id(euid).unwrap_or_exit(1);
 
     println!("{}", user.user);
     exit(0);


### PR DESCRIPTION
Migrating to the recently added `unwrap_or_exit` from `libextra`.

See https://github.com/redox-os/libextra/pull/11 for more details.



