### PR TITLE
DRY Principle + Misc fixes

### DIFF
--- a/src/bin/id.rs
+++ b/src/bin/id.rs
@@ -53,11 +53,12 @@ OPTIONS
         Display this help and exit.
 
 EXIT STATUS
-     The whoami utility exits 0 on success, and >0 if an error occurs.
+     The id utility exits 0 on success, and >0 if an error occurs.
 
 AUTHOR
     Written by Jose Narvaez.
 "#; /* @MANEND */
+
 
 pub fn main() {
     let stdout = io::stdout();
@@ -74,135 +75,99 @@ pub fn main() {
         .add_flag(&["r"]);
     parser.parse(env::args());
 
-    // Shows the help
+    // If the parser found the "help" tag...
     if parser.found("help") {
         print_msg(MAN_PAGE, &mut stdout, &mut stderr);
-        exit(0);
-    }
-
-    // Unrecognized flags
-    if let Err(err) = parser.found_invalid() {
+    // If the parser found invalid tags...
+    } else if let Err(err) = parser.found_invalid() {
         stderr.write_all(err.as_bytes()).try(&mut stderr);
         print_msg(HELP_INFO, &mut stdout, &mut stderr);
         exit(1);
-    }
-
-    // Display the different group IDs (effective and real)
-    // as white-space separated numbers, in no particular order.
-    if parser.found(&'G') {
+    // If the parser found G and...
+    } else if parser.found(&'G') {
+        //...found 'g' or 'u', which are mutually incompatible options...
         if any_of_found(&parser, &[&'g', &'u']) {
             let msg = "id: -G option must be used without others\n";
             print_msg(msg, &mut stdout, &mut stderr);
             print_msg(HELP_INFO, &mut stdout, &mut stderr);
             exit(1);
         }
-
+        //...Nothing else.
         let egid = get_egid().unwrap_or_exit(1);
-
         let gid = get_gid().unwrap_or_exit(1);
 
         print_msg(&format!("{} {}\n", egid, gid), &mut stdout, &mut stderr);
-        exit(0);
-   }
+    
+    // If the parser found 'u' and...
+    } else if parser.found(&'u'){
+	//...'g', which is a mutually incompatible option, 
+	if parser.found(&'g') {
+	     let msg = "id: specify either -u or -g but not both\n";
+	     print_msg(msg, &mut stdout, &mut stderr);
+	     print_msg(HELP_INFO, &mut stdout, &mut stderr);
+	     exit(1);
+	} else {
+	    //...'r', in which case, we show the real
+	    let uid_result = if parser.found(&'r') {
+		get_uid()
+	    } else {
+		get_euid() //Or not.
+	    };
+	    
+	    //...'n', to display the effective/real process user ID UNIX user name
+	    if parser.found(&'n') {
+		 let uid = uid_result.unwrap_or_exit(1);
+		 let user = get_user_by_id(uid).unwrap_or_exit(1);
 
-   // Check if people passed both -g -u which are mutually exclusive
-   if parser.found(&'u') && parser.found(&'g') {
-        let msg = "id: specify either -u or -g but not both\n";
-        print_msg(msg, &mut stdout, &mut stderr);
-        print_msg(HELP_INFO, &mut stdout, &mut stderr);
-        exit(1);
-   }
+		 print_msg(&format!("{}\n", user.user), &mut stdout, &mut stderr);
+	     //...nothing else of importance, in which case we display effective user ID 
+	     } else { 
+		 let euid = get_euid().unwrap_or_exit(1);
 
-   // Display effective/real process user ID UNIX user name
-   if parser.found(&'u') && parser.found(&'n') {
-        // Did they pass -r? F so, we show the real
-        let uid_result = if parser.found(&'r') {
-            get_uid()
-        } else {
-            get_euid()
-        };
-
-        let uid = uid_result.unwrap_or_exit(1);
-
-        let user = get_user_by_id(uid).unwrap_or_exit(1);
-
-        print_msg(&format!("{}\n", user.user), &mut stdout, &mut stderr);
-        exit(0);
-    }
-
-    // Display real user ID
-    if parser.found(&'u') && parser.found(&'r') {
-        let uid = get_uid().unwrap_or_exit(1);
-
-        print_msg(&format!("{}\n", uid), &mut stdout, &mut stderr);
-        exit(0);
-    }
-
-    // Display effective user ID
-    if parser.found(&'u') {
-        let euid = get_euid().unwrap_or_exit(1);
-
-        print_msg(&format!("{}\n", euid), &mut stdout, &mut stderr);
-        exit(0);
-    }
-
-   // Display effective/real process group ID UNIX group name
-   if parser.found(&'g') && parser.found(&'n') {
-        // Did they pass -r? If so we show the real one
+		 print_msg(&format!("{}\n", euid), &mut stdout, &mut stderr);
+	     }
+	 }
+    // If they found 'g' and...
+    } else if parser.found(&'g') {
+        //...'r', in which case we show the real group id
         let gid_result = if parser.found(&'r') {
             get_gid()
         } else {
-            get_egid()
+            get_egid() //Or not.
         };
+        
+	//...'n', in which case we display process group ID UNIX group name
+	if parser.found(&'n') {
+	    let gid = gid_result.unwrap_or_exit(1);
 
-        let gid = gid_result.unwrap_or_exit(1);
+	    let group = get_group_by_id(gid).unwrap_or_exit(1);
 
-        let group = get_group_by_id(gid).unwrap_or_exit(1);
-
-        print_msg(&format!("{}\n", group.group), &mut stdout, &mut stderr);
-        exit(0);
-    }
-
-    // Display the real group ID
-    if parser.found(&'g') && parser.found(&'r') {
-        let gid = get_gid().unwrap_or_exit(1);
-
-        print_msg(&format!("{}\n", gid), &mut stdout, &mut stderr);
-        exit(0);
-    }
-
-    // Display effective group ID
-    if parser.found(&'g') {
-        let egid = get_egid().unwrap_or_exit(1);
-
-        print_msg(&format!("{}\n", egid), &mut stdout, &mut stderr);
-        exit(0);
-    }
-
-    // -n does not apply if there is no -u or -g
-    if parser.found(&'n') && none_of_found(&parser, &[&'u', &'g']) {
+	    print_msg(&format!("{}\n", group.group), &mut stdout, &mut stderr);
+	//...Nothing else of importance
+	} else {
+	    let gid_result = gid_result.unwrap_or_exit(1);
+            print_msg(&format!("{}\n", gid_result), &mut stdout, &mut stderr);
+	}
+    // If they found -n, which does not apply if there is no -u or -g
+    } else if parser.found(&'n') {
         let msg = "id: the -n option must be used with either -u or -g\n";
         fail(msg, &mut stderr);
-    }
-
-    // -r does not apply if there is no -u or -g
-    if parser.found(&'r') && none_of_found(&parser, &[&'u', &'g']) {
+    // If they found -r, which does not apply if there is no -u or -g
+    } else if parser.found(&'r') {
         let msg = "id: the -r option must be used with either -u or -g\n";
         fail(msg, &mut stderr);
-    }
+    //If they used no tags at all, we show everything.
+    } else {
+	let euid = get_euid().unwrap_or_exit(1);
+	let egid = get_egid().unwrap_or_exit(1);
 
-    // We get everything we can and show
-    let euid = get_euid().unwrap_or_exit(1);
+	let user = get_user_by_id(euid).unwrap_or_exit(1);
+	let group = get_group_by_id(egid).unwrap_or_exit(1);
 
-    let egid = get_egid().unwrap_or_exit(1);
-
-    let user = get_user_by_id(euid).unwrap_or_exit(1);
-
-    let group = get_group_by_id(egid).unwrap_or_exit(1);
-
-    let msg = format!("uid={}({}) gid={}({})\n", euid, user.user, egid, group.group);
-    print_msg(&msg, &mut stdout, &mut stderr);
-    exit(0);
+	let msg = format!("uid={}({}) gid={}({})\n", euid, user.user, egid, group.group);
+	print_msg(&msg, &mut stdout, &mut stderr);
+     }
+     exit(0);
 }
 
 pub fn any_of_found<P: Hash + Eq + ?Sized>(parser: &ArgParser, flags: &[&P]) -> bool
@@ -213,12 +178,6 @@ pub fn any_of_found<P: Hash + Eq + ?Sized>(parser: &ArgParser, flags: &[&P]) -> 
     }
 
     false
-}
-
-fn none_of_found<P: Hash + Eq + ?Sized>(parser: &ArgParser, flags: &[&P]) -> bool
-    where Param: Borrow<P>
-{
-    !any_of_found(parser, flags)
 }
 
 fn print_msg(msg: &str, stdout: &mut StdoutLock, stderr: &mut Stderr) {


### PR DESCRIPTION
This code checked for several parser flags multiple times, thus violating the Do Not Repeat yourself clause of our holy bible Pragmatic Programming. The crimes contained in this source have subjected CPUs to potentially, count em, SEVERAL clock cycles of undue duress, and multiple seconds of several FLOSS programmers' time.

One hundred "hail stallmans" and three hymns to the glory of the standard text EDitor are due for penance.

Also fixed a typo in the man page.