### PR TITLE
Port to redox_users break-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -22,16 +22,14 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -39,27 +37,22 @@ name = "backtrace-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blake2-rfc"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -73,15 +66,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "dbghelp-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "extra"
 version = "0.1.0"
 source = "git+https://github.com/redox-os/libextra.git#f38608acd9cc00e1c8bd41a1a96d31becf239913"
@@ -91,7 +75,7 @@ name = "failure"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -106,33 +90,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -155,17 +114,8 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rand"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.1.32"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -173,7 +123,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -184,7 +134,7 @@ dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "extra 0.1.0 (git+https://github.com/redox-os/libextra.git)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -229,8 +179,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -249,11 +199,9 @@ name = "userutils"
 version = "0.1.0"
 dependencies = [
  "arg_parser 0.1.0 (git+https://github.com/redox-os/arg-parser.git)",
- "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "extra 0.1.0 (git+https://github.com/redox-os/libextra.git)",
  "liner 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.1.0 (git+https://github.com/redox-os/users.git)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -261,38 +209,41 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum arg_parser 0.1.0 (git+https://github.com/redox-os/arg-parser.git)" = "<none>"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
-"checksum arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0ef4a9820019a0c91d918918c93dc71d469f581a49b47ddc1d285d4270bbe2"
-"checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+"checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
-"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
+"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
-"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum extra 0.1.0 (git+https://github.com/redox-os/libextra.git)" = "<none>"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
-"checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
-"checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
+"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum liner 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f9e406164c25b420480023985bdf65cef366855666ad4cb12cd3eaee82dcb399"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
-"checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.1.0 (git+https://github.com/redox-os/users.git)" = "<none>"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
@@ -303,5 +254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "blake2-rfc"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +95,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +133,16 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rand"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,11 +158,12 @@ dependencies = [
 [[package]]
 name = "redox_users"
 version = "0.1.0"
-source = "git+https://github.com/redox-os/users.git#90e5ffe4df14361e9032c35bd96c38be8558a822"
+source = "git+https://github.com/redox-os/users.git#70b8a69ce6588693d05f3500b481c2620c1ee824"
 dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "extra 0.1.0 (git+https://github.com/redox-os/libextra.git)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -232,6 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
@@ -239,10 +270,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum extra 0.1.0 (git+https://github.com/redox-os/libextra.git)" = "<none>"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum liner 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f9e406164c25b420480023985bdf65cef366855666ad4cb12cd3eaee82dcb399"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.1.0 (git+https://github.com/redox-os/users.git)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,9 @@ name = "whoami"
 path = "src/bin/whoami.rs"
 
 [dependencies]
-argon2rs = { version = "0.2", default-features = false }
 arg_parser = { git = "https://github.com/redox-os/arg-parser.git" }
 extra = { git = "https://github.com/redox-os/libextra.git" }
 liner = "0.1"
-rand = "0.3"
 redox_syscall = "0.1"
 redox_termios = "0.1"
 redox_users = { git = "https://github.com/redox-os/users.git" }

--- a/src/bin/id.rs
+++ b/src/bin/id.rs
@@ -11,7 +11,7 @@ use std::process::exit;
 use extra::io::fail;
 use extra::option::OptionalExt;
 use arg_parser::{ArgParser, Param};
-use redox_users::{get_egid, get_gid, get_euid, get_uid, get_user_by_id, get_group_by_id};
+use redox_users::{get_egid, get_gid, get_euid, get_uid, AllUsers, AllGroups};
 
 const HELP_INFO: &'static str = "Try ‘id --help’ for more information.\n";
 const MAN_PAGE: &'static str = /* @MANSTART{id} */ r#"
@@ -86,6 +86,9 @@ pub fn main() {
         print_msg(HELP_INFO, &mut stdout, &mut stderr);
         exit(1);
     }
+    
+    let groups = AllGroups::new().unwrap_or_exit(1);
+    let users = AllUsers::new().unwrap_or_exit(1);
 
     // Display the different group IDs (effective and real)
     // as white-space separated numbers, in no particular order.
@@ -123,8 +126,7 @@ pub fn main() {
         };
 
         let uid = uid_result.unwrap_or_exit(1);
-
-        let user = get_user_by_id(uid).unwrap_or_exit(1);
+        let user = users.get_by_id(uid).unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", user.user), &mut stdout, &mut stderr);
         exit(0);
@@ -156,8 +158,9 @@ pub fn main() {
         };
 
         let gid = gid_result.unwrap_or_exit(1);
-
-        let group = get_group_by_id(gid).unwrap_or_exit(1);
+        
+        let groups = AllGroups::new().unwrap_or_exit(1);
+        let group = groups.get_by_id(gid).unwrap_or_exit(1);
 
         print_msg(&format!("{}\n", group.group), &mut stdout, &mut stderr);
         exit(0);
@@ -195,10 +198,10 @@ pub fn main() {
     let euid = get_euid().unwrap_or_exit(1);
 
     let egid = get_egid().unwrap_or_exit(1);
+    
+    let user = users.get_by_id(euid).unwrap_or_exit(1);
 
-    let user = get_user_by_id(euid).unwrap_or_exit(1);
-
-    let group = get_group_by_id(egid).unwrap_or_exit(1);
+    let group = groups.get_by_id(egid).unwrap_or_exit(1);
 
     let msg = format!("uid={}({}) gid={}({})\n", euid, user.user, egid, group.group);
     print_msg(&msg, &mut stdout, &mut stderr);

--- a/src/bin/passwd.rs
+++ b/src/bin/passwd.rs
@@ -2,11 +2,9 @@
 
 extern crate arg_parser;
 extern crate extra;
-extern crate rand;
 extern crate termion;
 extern crate redox_users;
 
-use rand::{Rng, OsRng};
 use std::{env, io};
 use std::io::Write;
 use std::process::exit;
@@ -14,7 +12,7 @@ use std::process::exit;
 use arg_parser::ArgParser;
 use extra::option::OptionalExt;
 use termion::input::TermRead;
-use redox_users::{User, get_uid, get_user_by_id, get_user_by_name};
+use redox_users::{get_uid, AllUsers};
 
 const MAN_PAGE: &'static str = /* @MANSTART{passwd} */ r#"
 NAME
@@ -58,76 +56,72 @@ fn main() {
     }
 
     let uid = get_uid().unwrap_or_exit(1);
+    let mut users = AllUsers::new().unwrap_or_exit(1);
     
-    let user = if parser.args.is_empty() {
-        get_user_by_id(uid).unwrap_or_exit(1)
-    } else {
-        let username = &parser.args[0];
-        get_user_by_name(username).unwrap_or_exit(1)
-    };
+    {
+        let user = if parser.args.is_empty() {
+            users.get_mut_by_id(uid).unwrap_or_exit(1)
+        } else {
+            let username = &parser.args[0];
+            users.get_mut_by_name(username).unwrap_or_exit(1)
+        };
 
-    let uid = uid as u32;
-    if user.uid == uid || uid == 0 {
-        let msg = format!("changing password for '{}' \n", user.user);
-        stdout.write_all(&msg.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-
-        let mut verified = false;
-        if user.hash == "" {
-            verified = true;
-        } else if user.uid == uid || uid != 0 {
-            stdout.write_all(b"current password: ").try(&mut stderr);
+        if user.uid == uid || uid == 0 {
+            let msg = format!("changing password for '{}' \n", user.user);
+            stdout.write_all(&msg.as_bytes()).try(&mut stderr);
             stdout.flush().try(&mut stderr);
 
-            if let Some(password) = stdin.read_passwd(&mut stdout).try(&mut stderr) {
-                stdout.write(b"\n").try(&mut stderr);
+            let mut verified = false;
+            if user.is_passwd_blank() {
+                verified = true;
+            } else if user.uid == uid || uid != 0 {
+                stdout.write_all(b"current password: ").try(&mut stderr);
                 stdout.flush().try(&mut stderr);
 
-                if user.verify_passwd(&password) {
-                    verified = true;
-                }
-            }
-        } else {
-            verified = true;
-        }
-
-        if verified {
-            stdout.write_all(b"new password: ").try(&mut stderr);;
-            stdout.flush().try(&mut stderr);;
-
-            if let Some(new_password) = stdin.read_passwd(&mut stdout).try(&mut stderr) {
-                stdout.write(b"\nconfirm password: ").try(&mut stderr);
-                stdout.flush().try(&mut stderr);
-
-                if let Some(confirm_password) = stdin.read_passwd(&mut stdout).try(&mut stderr) {
+                if let Some(password) = stdin.read_passwd(&mut stdout).try(&mut stderr) {
                     stdout.write(b"\n").try(&mut stderr);
-                    stdout.flush().try(&mut stderr);;
+                    stdout.flush().try(&mut stderr);
 
-                    if new_password == confirm_password {
-                        let salt = format!("{:X}", OsRng::new().try(&mut stderr).next_u64());
-                        let encoded_passwd = User::encode_passwd(&new_password, &salt);
-                        // TODO: Actually persist the new password to PASSWD_FILE
-                        let msg = format!("{}\n", encoded_passwd);
-                        stdout.write_all(&msg.as_bytes()).try(&mut stderr);
-                        stdout.flush().try(&mut stderr);
+                    verified = user.verify_passwd(&password)
+                }
+            } else {
+                verified = true;
+            }
+
+            if verified {
+                stdout.write_all(b"new password: ").try(&mut stderr);;
+                stdout.flush().try(&mut stderr);;
+
+                if let Some(new_password) = stdin.read_passwd(&mut stdout).try(&mut stderr) {
+                    stdout.write(b"\nconfirm password: ").try(&mut stderr);
+                    stdout.flush().try(&mut stderr);
+
+                    if let Some(confirm_password) = stdin.read_passwd(&mut stdout).try(&mut stderr) {
+                        stdout.write(b"\n").try(&mut stderr);
+                        stdout.flush().try(&mut stderr);;
+
+                        if new_password == confirm_password {
+                            user.set_passwd(&new_password).unwrap_or_exit(1);
+                        } else {
+                            eprintln!("passwd: new password does not match confirm password");
+                            exit(1);
+                        }
                     } else {
-                        eprintln!("passwd: new password does not match confirm password");
+                        eprintln!("passwd: no confirm password provided");
                         exit(1);
                     }
                 } else {
-                    eprintln!("passwd: no confirm password provided");
+                    eprintln!("passwd: no new password provided");
                     exit(1);
                 }
             } else {
-                eprintln!("passwd: no new password provided");
+                eprintln!("passwd: incorrect current password");
                 exit(1);
             }
         } else {
-            eprintln!("passwd: incorrect current password");
+            eprintln!("passwd: you do not have permission to set the password of '{}'", user.user);
             exit(1);
         }
-    } else {
-        eprintln!("passwd: you do not have permission to set the password of '{}'", user.user);
-        exit(1);
     }
+    users.save().unwrap_or_exit(1);
 }

--- a/src/bin/su.rs
+++ b/src/bin/su.rs
@@ -14,7 +14,7 @@ use std::str;
 use arg_parser::ArgParser;
 use extra::option::OptionalExt;
 use termion::input::TermRead;
-use redox_users::{get_euid, get_uid, AllUsers};
+use redox_users::{get_uid, AllUsers};
 use userutils::spawn_shell;
 
 const MAN_PAGE: &'static str = /* @MANSTART{su} */ r#"

--- a/src/bin/su.rs
+++ b/src/bin/su.rs
@@ -14,7 +14,7 @@ use std::str;
 use arg_parser::ArgParser;
 use extra::option::OptionalExt;
 use termion::input::TermRead;
-use redox_users::{get_uid, get_user_by_name};
+use redox_users::{get_euid, get_uid, AllUsers};
 use userutils::spawn_shell;
 
 const MAN_PAGE: &'static str = /* @MANSTART{su} */ r#"
@@ -52,8 +52,7 @@ pub fn main() {
 
     // Shows the help
     if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
+        write!(stdout, "{}", MAN_PAGE).unwrap_or_exit(1);
         exit(0);
     }
 
@@ -64,37 +63,29 @@ pub fn main() {
     };
 
     let uid = get_uid().unwrap_or_exit(1);
+    
+    let users = AllUsers::new().unwrap_or_exit(1);
+    let user = users.get_by_name(&target_user).unwrap_or_exit(1);
 
-    let user = get_user_by_name(&target_user).unwrap_or_exit(1);
-
-    // If we are root and the new user account has no password
-    if uid == 0 && user.hash == "" {
-        stdout.write(b"\n").try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-
-        // Spawn a shell as the new user
-        exit(spawn_shell(user).code().unwrap_or(1));
+    // If the user executing su is root, then they can do anything without a password.
+    // Same if the user we're being asked to login as doesn't have a password.
+    if uid == 0 || user.is_passwd_blank() {
+        writeln!(stdout).unwrap_or_exit(1);
+        exit(spawn_shell(user).unwrap_or_exit(1));
     } else {
-        // Ask for the new user account's password
-        stdout.write_all(b"password: ").try(&mut stderr);
-        stdout.flush().try(&mut stderr);
+        write!(stdout, "password: ").unwrap_or_exit(1);
+        stdout.flush().unwrap_or_exit(1);
 
         // Read the password, reading an empty string if CTRL-d is specified
         let password = stdin.read_passwd(&mut stdout).try(&mut stderr).unwrap_or(String::new());
 
-        // Write a newline
-        stdout.write(b"\n").try(&mut stderr);
-        stdout.flush().try(&mut stderr);
+        writeln!(stderr, "\n").unwrap_or_exit(1);
 
-        // If the password is correct
         if user.verify_passwd(&password) {
-            // Spawn a shell as the new user
-            exit(spawn_shell(user).code().unwrap_or(1));
+            exit(spawn_shell(user).unwrap_or_exit(1));
+        } else {
+            writeln!(stderr, "su: authentication failed").unwrap_or_exit(1);
+            exit(1);
         }
     }
-
-    // All other conditions will return an error
-    stderr.write(b"su: authentication failed\n").try(&mut stderr);
-    stderr.flush().try(&mut stderr);
-    exit(1);
 }

--- a/src/bin/whoami.rs
+++ b/src/bin/whoami.rs
@@ -9,7 +9,7 @@ use std::process::exit;
 use std::env;
 use arg_parser::ArgParser;
 use extra::option::OptionalExt;
-use redox_users::{get_euid, get_user_by_id};
+use redox_users::{get_euid, AllUsers};
 
 const MAN_PAGE: &'static str = /* @MANSTART{whoami} */ r#"
 NAME
@@ -49,8 +49,9 @@ fn main() {
     }
 
     let euid = get_euid().unwrap_or_exit(1);
-
-    let user = get_user_by_id(euid).unwrap_or_exit(1);
+    
+    let users = AllUsers::new().unwrap_or_exit(1);
+    let user = users.get_by_id(euid).unwrap_or_exit(1);
 
     println!("{}", user.user);
     exit(0);


### PR DESCRIPTION
All the utilities use the new API I defined in mu recent PR to
redox_users. `su`'s behavior was also fixed. Also fixed passwd so that it actually persists changes to the filesystem.

I also updated Cargo.toml (removing unused deps). This may require
another commit after my first PR is merged in order to appropriately
update Cargo.lock and make sure everything builds.

This PR is very dependent on https://github.com/redox-os/users/pull/8, do not merge unless that has also been merged! I would also recommend waiting until I can double check to make sure this builds with upstream having been updated (my git process was not what it should have been...)